### PR TITLE
Fix RuntimeError by ensuring attn_mask is None when is_causal=True

### DIFF
--- a/dia/layers.py
+++ b/dia/layers.py
@@ -199,6 +199,7 @@ class Attention(nn.Module):
         cache: KVCache | None = None,  # None in Encoder, KVCache in Decoder
         prefill: bool = False,
         is_causal: bool = False,
+        current_idx: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, tuple[torch.Tensor, torch.Tensor] | None]:
         """
         Performs attention calculation with optional KV caching.
@@ -241,18 +242,21 @@ class Attention(nn.Module):
             if cache is None:
                 attn_k = Xk_BxKxSxH
                 attn_v = Xv_BxKxSxH
+            elif prefill:
+                attn_k, attn_v = Xk_BxKxSxH, Xv_BxKxSxH
+                cache.prefill(attn_k, attn_v)
             else:
-                if prefill:
-                    attn_k, attn_v = Xk_BxKxSxH, Xv_BxKxSxH
-                    cache.prefill(attn_k, attn_v)
-                else:
-                    attn_k, attn_v = cache.update(Xk_BxKxSxH, Xv_BxKxSxH)
+                attn_k, attn_v = cache.update(Xk_BxKxSxH, Xv_BxKxSxH, current_idx)
+
+        # If is_causal is True, sdpa handles masking internally, so attn_mask should be None.
+        # Otherwise, use the provided attn_mask (e.g., for padding in encoder).
+        effective_attn_mask = attn_mask if not is_causal else None
 
         attn_output = F.scaled_dot_product_attention(
             Xq_BxNxTxH,
             attn_k,
             attn_v,
-            attn_mask=attn_mask,
+            attn_mask=effective_attn_mask,
             scale=1.0,
             enable_gqa=self.num_gqa_groups > 1,
             is_causal=is_causal,
@@ -427,19 +431,23 @@ class DecoderLayer(nn.Module):
         self_attn_cache: KVCache | None = None,
         cross_attn_cache: KVCache | None = None,
         prefill: bool = False,
+        current_idx: int = 0,
     ) -> torch.Tensor:
         residual = x
         x_norm = self.pre_sa_norm(x).to(self.compute_dtype)
+
+        self_attn_mask = state.casual_attn_mask[None, None, current_idx]
 
         sa_out = self.self_attention(
             Xq=x_norm,  # (2, 1, D)
             Xkv=x_norm,  # (2, 1, D)
             q_positions=state.dec_positions,  # (2, 1)
             kv_positions=state.dec_positions,  # (2, 1)
-            attn_mask=None,
+            attn_mask=self_attn_mask,
             cache=self_attn_cache,
             prefill=prefill,
             is_causal=prefill,
+            current_idx=current_idx,
         )
 
         x = residual + sa_out
@@ -451,8 +459,8 @@ class DecoderLayer(nn.Module):
             Xkv=state.enc_out,
             q_positions=state.dec_positions,
             kv_positions=state.enc_positions,
-            attn_mask=state.dec_cross_attn_mask,
             cache=cross_attn_cache,
+            current_idx=current_idx,
         )
         x = residual + ca_out
 
@@ -503,6 +511,7 @@ class Decoder(nn.Module):
         self,
         enc_out: torch.Tensor,  # (B, S, E)
         enc_positions: torch.Tensor,  # (B, S)
+        k_padding_mask: torch.Tensor | None = None,
     ) -> list[KVCache]:
         """
         Computes the Key and Value tensors for cross-attention for each layer from the encoder output.
@@ -517,6 +526,8 @@ class Decoder(nn.Module):
             k_proj = cross_attn_module.rotary_emb(k_proj, position=enc_positions)
             k = k_proj.transpose(1, 2)
             v = v_proj.transpose(1, 2)
+            if k_padding_mask is not None:
+                k = k.masked_fill(~k_padding_mask.unsqueeze(1).unsqueeze(3), 0.0)
 
             per_layer_kv_cache.append(KVCache.from_kv(k, v))
 
@@ -526,6 +537,7 @@ class Decoder(nn.Module):
         self,
         tgt_ids_Bx1xC: torch.Tensor,  # [B, 1, C]
         state: DecoderInferenceState,
+        current_idx: int,
     ) -> torch.Tensor:
         """
         Performs a single decoding step, managing KV caches layer by layer.
@@ -549,6 +561,7 @@ class Decoder(nn.Module):
                 state,
                 self_attn_cache=self_cache,
                 cross_attn_cache=cross_cache,
+                current_idx=current_idx,
             )
 
         x = self.norm(x)


### PR DESCRIPTION
Prevents an error by modifying the Attention module: avoid passing an explicit attn_mask to F.scaled_dot_product_attention when is_causal=True. 

This allows the function's internal causal masking mechanism to be used without conflict, during operations like decoder prefill.

Otherwise getting the following error:

```
Error processing task 1 ('C:_myDrive\repos\auto-vlog\AutoVlogProj\temp_video_processing\audio_maker_temp\girl and a stick in a forest\chunk_2.wav'): _scaled_dot_product_attention: Explicit attn_mask should not be set when is_causal=True
Traceback (most recent call last):
File "C:_myDrive\repos\auto-vlog\dia\cli.py", line 168, in process_task
output_audio = model.generate(
^^^^^^^^^^^^^^^
File "C:_myDrive\repos\auto-vlog\venv\Lib\site-packages\torch\utils_contextlib.py", line 116, in decorate_context
return func(*args, **kwargs)
^^^^^^^^^^^^^^^^^^^^^
File "C:_myDrive\repos\auto-vlog\dia\dia\model.py", line 407, in generate
dec_state, dec_output = self._prepare_generation(full_text, audio_prompt, verbose)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "C:_myDrive\repos\auto-vlog\dia\dia\model.py", line 289, in _prepare_generation
self.model.decoder.forward(tokens_BxTxC, dec_state)
File "C:_myDrive\repos\auto-vlog\dia\dia\layers.py", line 605, in forward
x = layer(x, state, self_attn_cache=self_cache, cross_attn_cache=cross_cache, prefill=True)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "C:_myDrive\repos\auto-vlog\venv\Lib\site-packages\torch\nn\modules\module.py", line 1739, in _wrapped_call_impl
return self._call_impl(*args, **kwargs)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "C:_myDrive\repos\auto-vlog\venv\Lib\site-packages\torch\nn\modules\module.py", line 1750, in _call_impl
return forward_call(*args, **kwargs)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "C:_myDrive\repos\auto-vlog\dia\dia\layers.py", line 437, in forward
sa_out = self.self_attention(
^^^^^^^^^^^^^^^^^^^^
File "C:_myDrive\repos\auto-vlog\venv\Lib\site-packages\torch\nn\modules\module.py", line 1739, in _wrapped_call_impl
return self._call_impl(*args, **kwargs)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "C:_myDrive\repos\auto-vlog\venv\Lib\site-packages\torch\nn\modules\module.py", line 1750, in _call_impl
return forward_call(*args, **kwargs)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "C:_myDrive\repos\auto-vlog\dia\dia\layers.py", line 251, in forward
attn_output = F.scaled_dot_product_attention(
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: _scaled_dot_product_attention: Explicit attn_mask should not be set when is_causal=True
Skipping task due to error.
```